### PR TITLE
Drop init_charset() method

### DIFF
--- a/db.php
+++ b/db.php
@@ -239,26 +239,6 @@ class hyperdb extends wpdb {
 	}
 
 	/**
-	 * Sets $this->charset and $this->collate
-	 */
-	public function init_charset() {
-		if ( function_exists( 'is_multisite' ) && is_multisite() ) {
-			$this->charset = 'utf8';
-			if ( defined( 'DB_COLLATE' ) && DB_COLLATE ) {
-				$this->collate = DB_COLLATE;
-			} else {
-				$this->collate = 'utf8_general_ci';
-			}
-		} elseif ( defined( 'DB_COLLATE' ) ) {
-			$this->collate = DB_COLLATE;
-		}
-
-		if ( defined( 'DB_CHARSET' ) ) {
-			$this->charset = DB_CHARSET;
-		}
-	}
-
-	/**
 	 * Add the connection parameters for a database
 	 */
 	public function add_database( $db ) {


### PR DESCRIPTION
`wpdb::init_charset()` exists since 3.1.0, we don't need our own implementation.