### PR TITLE
fix: resolve warnings in php 8

### DIFF
--- a/db.php
+++ b/db.php
@@ -592,6 +592,8 @@ class hyperdb extends wpdb {
 				// Overlay $server if it was extracted from a callback
 				if ( isset( $server ) && is_array( $server ) ) {
 					extract( $server, EXTR_OVERWRITE );
+				} else {
+					$server = null;
 				}
 
 				// Split again in case $server had host:port


### PR DESCRIPTION
Resolves the following warnings when upgrading to PHP 8:
-  compact(): Undefined variable $server in db.php on line 722
-  Undefined variable $server in db.php on line 726