### PR TITLE
Refill $this->unused_servers when we run out of them

### DIFF
--- a/db.php
+++ b/db.php
@@ -554,7 +554,13 @@ class hyperdb extends wpdb {
 		}
 
 		// Make a list of at least $this->min_tries connections to try, repeating as necessary.
-		if ( ! isset( $this->unused_servers[ $dbhname ] ) ) {
+		//
+		// $this->unused_servers[ $dbhname ] might be either:
+		//
+		// * Unset if it's the first time the list of unused servers is being generated, or
+		// * An empty array if all the used servers got disconnected, e.g. there was a single server for a dataset, and
+		//   it didn't respond to ping.
+		if ( empty( $this->unused_servers[ $dbhname ] ) ) {
 			// Put the groups in order by priority
 			ksort( $this->hyper_servers[ $dataset ][ $operation ] );
 


### PR DESCRIPTION
If `db_connect()` ended up disconnecting all servers that serve a dataset (e.g. on ping failures), `$this->unused_servers` used to remain empty, so the database handler didn't attempt to reconnect to any of the dataset's servers.

This patch makes `db_connect()` refill `$this->unused_servers` not only when it's unset (i.e. on the first run) but also when it's empty, i.e. when all of the used servers get disconnected from.

Fixes #81.

References #40 (this PR should remediate (most?) cases when HyperDB doesn't find what to connect to, but I think a proper fix for #40 would be a minor revamp on how things get logged).

## Test Plan

1. Check out this branch / apply this patch
2. From #81, follow the "Set up" and "Buggy behavior on HyperDB 1.8" steps in the "How to reproduce" section
3. Make sure that `timeouts.php` manages to reconnect to the database after ping failures, i.e. you don't see any `Database error`s while running the script:

```
0.009290 s: Works
1.026420 s: Works
2.043919 s: Works
3.061042 s: Works
<...>
71.382320 s: Works
<...>
```
