### PR TITLE
PHP Compatibility: Drop keys on $args that get passed to call_user_func_array in run_callbacks method, drop passing by reference

### DIFF
--- a/db.php
+++ b/db.php
@@ -372,6 +372,12 @@ class hyperdb extends wpdb {
 		if ( ! isset( $args ) ) {
 			$args = array( &$this );
 		} elseif ( is_array( $args ) ) {
+			// 8.0+ changed the behavior of call_user_func_array(), associative arrays would turn into named attributes
+			// Here we discard the keys and hope for the best
+			if ( version_compare( PHP_VERSION, '8.0.0', '>=' ) ) {
+				$args = array_values( $args );
+			}
+
 			$args[] = &$this;
 		} else {
 			$args = array( $args, &$this );

--- a/db.php
+++ b/db.php
@@ -374,7 +374,7 @@ class hyperdb extends wpdb {
 		} elseif ( is_array( $args ) ) {
 			// 8.0+ changed the behavior of call_user_func_array(), associative arrays would turn into named attributes
 			// Here we discard the keys and hope for the best
-			if ( version_compare( PHP_VERSION, '8.0.0', '>=' ) ) {
+			if ( PHP_MAJOR_VERSION >= 8 ) {
 				$args = array_values( $args );
 			}
 

--- a/db.php
+++ b/db.php
@@ -370,14 +370,14 @@ class hyperdb extends wpdb {
 		}
 
 		if ( ! isset( $args ) ) {
-			$args = array( &$this );
+			$args = array( $this );
 		} elseif ( is_array( $args ) ) {
 			// 8.0+ changed the behavior of call_user_func_array(), associative arrays would turn into named attributes
 			// Here we discard the keys and hope for the best
 			$args = array_values( $args );
-			$args[] = &$this;
+			$args[] = $this;
 		} else {
-			$args = array( $args, &$this );
+			$args = array( $args, $this );
 		}
 
 		foreach ( $this->hyper_callbacks[ $group ] as $func ) {

--- a/db.php
+++ b/db.php
@@ -374,7 +374,7 @@ class hyperdb extends wpdb {
 		} elseif ( is_array( $args ) ) {
 			// 8.0+ changed the behavior of call_user_func_array(), associative arrays would turn into named attributes
 			// Here we discard the keys and hope for the best
-			$args = array_values( $args );
+			$args   = array_values( $args );
 			$args[] = $this;
 		} else {
 			$args = array( $args, $this );

--- a/db.php
+++ b/db.php
@@ -374,10 +374,7 @@ class hyperdb extends wpdb {
 		} elseif ( is_array( $args ) ) {
 			// 8.0+ changed the behavior of call_user_func_array(), associative arrays would turn into named attributes
 			// Here we discard the keys and hope for the best
-			if ( PHP_MAJOR_VERSION >= 8 ) {
-				$args = array_values( $args );
-			}
-
+			$args = array_values( $args );
 			$args[] = &$this;
 		} else {
 			$args = array( $args, &$this );


### PR DESCRIPTION
PHP changed the behavior for [call_user_func_array](https://www.php.net/manual/en/function.call-user-func-array.php) so that associative arrays turn into named arguments - so this blows up in our faces.

We don't like that.