### PR TITLE
Sync up with 1.9 on dotorg

### DIFF
--- a/db.php
+++ b/db.php
@@ -92,7 +92,7 @@ class hyperdb extends wpdb {
 	 * The current mysql link resource
 	 * @var mysqli|resource|false|null
 	 */
-	public $dbh;
+	protected $dbh;
 
 	/**
 	 * Associative array (dbhname => dbh) for established mysql connections
@@ -181,16 +181,22 @@ class hyperdb extends wpdb {
 	public $used_servers = array();
 
 	/**
-	 * Lookup array (dbhname => (group, key)) prioritized for connections
-	 * @var array
-	 */
-	public $unused_servers = array();
-
-	/**
 	 * Lookup array (dbhname => int) of the number of unique servers in the config
 	 * @var array
 	 */
 	public $unique_servers = array();
+
+	/**
+ 	 * A list of servers we found to be read-only
+ 	 * @var array
+ 	 */
+	public $read_only_servers = array();
+
+	/**
+ 	 * A list of servers' state
+ 	 * @var array
+ 	 */
+	public $servers_state = array();
 
 	/**
 	 * Whether to save debug_backtrace in save_query_callback. You may wish
@@ -556,55 +562,39 @@ class hyperdb extends wpdb {
 			return $this->log_and_bail( "No databases available with $this->table ($dataset)" );
 		}
 
-		// Make a list of at least $this->min_tries connections to try, repeating as necessary.
-		//
-		// $this->unused_servers[ $dbhname ] might be either:
-		//
-		// * Unset if it's the first time the list of unused servers is being generated, or
-		// * An empty array if all the used servers got disconnected, e.g. there was a single server for a dataset, and
-		//   it didn't respond to ping.
-		if ( empty( $this->unused_servers[ $dbhname ] ) ) {
-			// Put the groups in order by priority
-			ksort( $this->hyper_servers[ $dataset ][ $operation ] );
+		// Put the groups in order by priority
+		ksort( $this->hyper_servers[ $dataset ][ $operation ] );
 
-			$servers = array();
+		// Make a list of at least $this->min_tries connections to try, repeating as necessary.
+		$servers = array();
+		$this->unique_servers[ $dbhname ] = array();
+		do {
 			foreach ( $this->hyper_servers[ $dataset ][ $operation ] as $group => $items ) {
 				$keys = array_keys( $items );
 				shuffle( $keys );
 				foreach ( $keys as $key ) {
 					$servers[] = compact( 'group', 'key' );
+
+					if ( ! isset( $this->unique_servers[ $dbhname ][ $items[$key]['host'] ] ) ) {
+						$this->unique_servers[ $dbhname ][ $items[$key]['host'] ] = true;
+					}
 				}
 			}
 
-			$this->unique_servers[ $dbhname ] = count( $servers );
-			if ( 0 === $this->unique_servers[ $dbhname ] ) {
+			if ( 0 === count( $this->unique_servers[ $dbhname ] ) ) {
 				return $this->log_and_bail( "No database servers were found to match the query ($this->table, $dataset)" );
 			}
-
-			$this->unused_servers[ $dbhname ] = $servers;
-
-			// Repeat the server list until there are enough for retries (unless master has fallbacks)
-			if ( ! ( $use_master && $this->unique_servers[ $dbhname ] > 1 ) ) {
-				// phpcs:ignore Squiz.PHP.DisallowSizeFunctionsInLoops.Found
-				while ( count( $this->unused_servers[ $dbhname ] ) < $this->min_tries ) {
-					$this->unused_servers[ $dbhname ] = array_merge( $this->unused_servers[ $dbhname ], $servers );
-				}
-			}
-		}
+		} while ( count( $servers ) < $this->min_tries );
 
 		// Connect to a database server
 		do {
 			$unique_lagged_slaves = array();
+			$unique_readonly_masters = array();
 			$success              = false;
+			$tries_remaining      = count( $servers );
 
-			// phpcs:ignore WordPress.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
-			while ( ( $group_key = array_shift( $this->unused_servers[ $dbhname ] ) ) ) {
-				$tries_remaining = count( $this->unused_servers[ $dbhname ] );
-
-				// If all servers are lagged, we need to start ignoring the lag and retry
-				if ( count( $unique_lagged_slaves ) == $this->unique_servers[ $dbhname ] ) {
-					break;
-				}
+			foreach ( $servers as $group_key ) {
+				--$tries_remaining;
 
 				// Variables: $group, $key
 				extract( $group_key, EXTR_OVERWRITE );
@@ -643,10 +633,15 @@ class hyperdb extends wpdb {
 					$min_group = $group;
 				}
 
-				// Skip master if read-only and fallback masters are configured
-				if ( $use_master && $this->unique_servers[ $dbhname ] > 1 ) {
-					// Load server state from acpu, bypassing check_tcp_responsiveness()
-					if ( $this->server_marked_read_only( $host, $port, $dbhname ) ) {
+				// If a master is read-only and we have others which might not be RO, go to the next one
+				if ( $use_master && $this->unique_servers[ $dbhname ] > 1 && empty( $ignore_server_read_only ) ) {
+					if ( count( $unique_readonly_masters ) == count( $this->unique_servers[ $dbhname ] ) ) {
+						$ignore_server_read_only = true; // All are read-only, ignore RO and retry
+						continue 2;
+					}
+
+					if ( $this->is_server_marked_read_only( $host, $port ) ) {
+						$unique_readonly_masters[ "$host:$port" ] = true;
 						continue;
 					}
 				}
@@ -663,7 +658,7 @@ class hyperdb extends wpdb {
 				) {
 					// If it is the last lagged slave and it is with the best preference we will ignore its lag
 					if ( ! isset( $unique_lagged_slaves[ "$host:$port" ] )
-						&& count( $unique_lagged_slaves ) + 1 == $this->unique_servers[ $dbhname ]
+						&& count( $unique_lagged_slaves ) + 1 == count( $this->unique_servers[ $dbhname ] )
 						&& $group == $min_group ) {
 						$this->lag_threshold = null;
 					} else {
@@ -699,7 +694,7 @@ class hyperdb extends wpdb {
 						&& ( $lagged_status = $this->get_lag() ) === HYPERDB_LAG_BEHIND // phpcs:ignore Squiz.PHP.DisallowMultipleAssignments.FoundInControlStructure
 						&& ! (
 							! isset( $unique_lagged_slaves[ "$host:$port" ] )
-							&& count( $unique_lagged_slaves ) + 1 === $this->unique_servers[ $dbhname ]
+							&& count( $unique_lagged_slaves ) + 1 === count( $this->unique_servers[ $dbhname ] )
 							&& $group == $min_group
 						)
 					) {
@@ -730,7 +725,7 @@ class hyperdb extends wpdb {
 				$errno = $this->ex_mysql_errno();
 				if ( ( HYPERDB_CONN_HOST_ERROR == $errno || HYPERDB_CONNNECTION_ERROR == $errno ) &&
 					( 'up' == $server_state || ! $tries_remaining ) ) {
-					$this->mark_server_as_down( $host, $port, $dbhname );
+					$this->mark_server_as_down( $host, $port );
 					$server_state = 'down';
 				}
 
@@ -1014,7 +1009,11 @@ class hyperdb extends wpdb {
 			$this->dbhname_heartbeats[ $this->dbhname ]['last_errno'] = $this->last_errno;
 
 			// Write failed, use fallback master connection
-			if ( HYPERDB_ER_OPTION_PREVENTS_STATEMENT == $this->last_errno && $this->unique_servers[ $this->dbhname ] > 1 && ! empty( $this->unused_servers[ $this->dbhname ] ) ) {
+			if ( HYPERDB_ER_OPTION_PREVENTS_STATEMENT == $this->last_errno &&
+				false !== strpos( $this->last_error, 'read-only' ) &&
+				count( $this->unique_servers[ $this->dbhname ] ) > 1 &&
+				! $this->is_server_marked_read_only() )
+			{
 				// Stay away from this server
 				$this->disconnect( $this->dbhname );
 				$this->mark_server_read_only();
@@ -1022,7 +1021,6 @@ class hyperdb extends wpdb {
 				$msg = "Can't write to $this->dbhname - server switched to read-only mode. Retrying on configured fallback connection.";
 				$this->print_error( $msg );
 
-				// Try again and db_connect will use the next unused server
 				return $this->query( $query );
 			}
 
@@ -1039,7 +1037,6 @@ class hyperdb extends wpdb {
 		if ( preg_match( '/^\s*(insert|delete|update|replace|alter)\s/i', $query ) ) {
 			$this->rows_affected = $this->ex_mysql_affected_rows( $this->dbh );
 
-			// Take note of the insert_id
 			if ( preg_match( '/^\s*(insert|replace)\s/i', $query ) ) {
 				$this->insert_id = $this->ex_mysql_insert_id( $this->dbh );
 			}
@@ -1146,6 +1143,8 @@ class hyperdb extends wpdb {
 				} else {
 					return version_compare( $client_version, '5.5.3', '>=' );
 				}
+			case 'utf8mb4_520': // since WP 4.6
+				return $this->has_cap( 'utf8mb4', $dbh_or_table ) && version_compare( $version, '5.6', '>=' );
 		endswitch;
 
 		return false;
@@ -1279,45 +1278,60 @@ class hyperdb extends wpdb {
 			}
 		}
 
+		if ( ! empty( $this->servers_state[ "$host:$port" ] ) ) {
+			return $this->servers_state[ "$host:$port" ];
+		}
+
 		if ( ! function_exists( 'apcu_store' ) ) {
 			return 'up';
 		}
 
-		$server_state = apcu_fetch( "server_state_$host$port$dbhname" );
+		$server_state = apcu_fetch( "server_state_$host$port" );
 		if ( ! $server_state ) {
 			return 'up';
 		}
 
-		return $server_state;
+		return $this->servers_state[ "$host:$port" ] = $server_state;
 	}
 
-	// Signal to other PHP workers that a server can not take writes
-	public function mark_server_read_only() {
+	public function mark_server_as_down( $host, $port, $apcu_ttl = 10 ) {
+		$this->servers_state[ "$host:$port" ] = 'down';
+
 		if ( ! function_exists( 'apcu_store' ) ) {
 			return;
 		}
 
-		$host    = $this->last_connection['host'];
-		$port    = $this->last_connection['port'];
-		$dbhname = $this->dbhname;
-
-		apcu_add( "server_readonly_$host$port$dbhname", 'read_only', 120 );
+		apcu_add( "server_state_$host$port", 'down', $apcu_ttl );
 	}
 
-	public function server_marked_read_only( $host, $port, $dbhname ) {
+	// Signal to other PHP workers that a server can not take writes
+	public function mark_server_read_only( $host = null, $port = null ) {
+		$host_key = $host ? "$host:$port" : $this->current_host;
+
+		$this->read_only_servers[ $host_key ] = true;
+
+		if ( ! function_exists( 'apcu_store' ) ) {
+			return;
+		}
+
+		apcu_add( "server_readonly_$host_key", 'read_only', 120 );
+	}
+
+	public function is_server_marked_read_only( $host = null, $port = null ) {
+		$host_key = $host ? "$host:$port" : $this->current_host;
+
+		if ( ! empty( $this->read_only_servers[ $host_key ] ) ) {
+			return true;
+		}
+
 		if ( ! function_exists( 'apcu_store' ) ) {
 			return false;
 		}
 
-		return 'read_only' === apcu_fetch( "server_readonly_$host$port$dbhname" );
-	}
+		if ( 'read_only' !== apcu_fetch( "server_readonly_$host_key" ) )
+			return false;
 
-	public function mark_server_as_down( $host, $port, $dbhname, $apcu_ttl = 10 ) {
-		if ( ! function_exists( 'apcu_store' ) ) {
-			return;
-		}
-
-		apcu_add( "server_readonly_$host$port$dbhname", 'down', $apcu_ttl );
+		return $this->read_only_servers[ $host_key ] = true;
 	}
 
 	public function set_connect_timeout( $tag, $use_master, $tries_remaining ) {

--- a/db.php
+++ b/db.php
@@ -187,15 +187,15 @@ class hyperdb extends wpdb {
 	public $unique_servers = array();
 
 	/**
- 	 * A list of servers we found to be read-only
- 	 * @var array
- 	 */
+	 * A list of servers we found to be read-only
+	 * @var array
+	 */
 	public $read_only_servers = array();
 
 	/**
- 	 * A list of servers' state
- 	 * @var array
- 	 */
+	 * A list of servers' state
+	 * @var array
+	 */
 	public $servers_state = array();
 
 	/**
@@ -566,7 +566,7 @@ class hyperdb extends wpdb {
 		ksort( $this->hyper_servers[ $dataset ][ $operation ] );
 
 		// Make a list of at least $this->min_tries connections to try, repeating as necessary.
-		$servers = array();
+		$servers                          = array();
 		$this->unique_servers[ $dbhname ] = array();
 		do {
 			foreach ( $this->hyper_servers[ $dataset ][ $operation ] as $group => $items ) {
@@ -575,8 +575,8 @@ class hyperdb extends wpdb {
 				foreach ( $keys as $key ) {
 					$servers[] = compact( 'group', 'key' );
 
-					if ( ! isset( $this->unique_servers[ $dbhname ][ $items[$key]['host'] ] ) ) {
-						$this->unique_servers[ $dbhname ][ $items[$key]['host'] ] = true;
+					if ( ! isset( $this->unique_servers[ $dbhname ][ $items[ $key ]['host'] ] ) ) {
+						$this->unique_servers[ $dbhname ][ $items[ $key ]['host'] ] = true;
 					}
 				}
 			}
@@ -584,14 +584,14 @@ class hyperdb extends wpdb {
 			if ( 0 === count( $this->unique_servers[ $dbhname ] ) ) {
 				return $this->log_and_bail( "No database servers were found to match the query ($this->table, $dataset)" );
 			}
-		} while ( count( $servers ) < $this->min_tries );
+		} while ( count( $servers ) < $this->min_tries ); // phpcs:ignore Squiz.PHP.DisallowSizeFunctionsInLoops.Found
 
 		// Connect to a database server
 		do {
-			$unique_lagged_slaves = array();
+			$unique_lagged_slaves    = array();
 			$unique_readonly_masters = array();
-			$success              = false;
-			$tries_remaining      = count( $servers );
+			$success                 = false;
+			$tries_remaining         = count( $servers );
 
 			foreach ( $servers as $group_key ) {
 				--$tries_remaining;
@@ -1012,8 +1012,7 @@ class hyperdb extends wpdb {
 			if ( HYPERDB_ER_OPTION_PREVENTS_STATEMENT == $this->last_errno &&
 				false !== strpos( $this->last_error, 'read-only' ) &&
 				count( $this->unique_servers[ $this->dbhname ] ) > 1 &&
-				! $this->is_server_marked_read_only() )
-			{
+				! $this->is_server_marked_read_only() ) {
 				// Stay away from this server
 				$this->disconnect( $this->dbhname );
 				$this->mark_server_read_only();
@@ -1291,7 +1290,7 @@ class hyperdb extends wpdb {
 			return 'up';
 		}
 
-		return $this->servers_state[ "$host:$port" ] = $server_state;
+		return $this->servers_state[ "$host:$port" ] = $server_state; // phpcs:ignore Squiz.PHP.DisallowMultipleAssignments.Found
 	}
 
 	public function mark_server_as_down( $host, $port, $apcu_ttl = 10 ) {
@@ -1328,10 +1327,10 @@ class hyperdb extends wpdb {
 			return false;
 		}
 
-		if ( 'read_only' !== apcu_fetch( "server_readonly_$host_key" ) )
+		if ( 'read_only' !== apcu_fetch( "server_readonly_$host_key" ) ) //phpcs:ignore Generic.ControlStructures.InlineControlStructure.NotAllowed
 			return false;
 
-		return $this->read_only_servers[ $host_key ] = true;
+		return $this->read_only_servers[ $host_key ] = true; // phpcs:ignore Squiz.PHP.DisallowMultipleAssignments.Found
 	}
 
 	public function set_connect_timeout( $tag, $use_master, $tries_remaining ) {


### PR DESCRIPTION
This PR syncs up with 1.9 on dotorg: https://plugins.svn.wordpress.org/hyperdb/tags/1.9/

It leaves the changes from https://github.com/Automattic/HyperDB/pull/75 intact though.