### PR TITLE
Fix error "TypeError: mysqli_num_fields(): Argument #1 ($result) must be of type mysqli_result, null given"

### DIFF
--- a/db.php
+++ b/db.php
@@ -1578,6 +1578,10 @@ class hyperdb extends wpdb {
 			return @mysql_num_fields( $result );
 		}
 
+		if ( ! $this->is_mysql_result( $result ) ) {
+			return false;
+		}
+
 		return @mysqli_num_fields( $result );
 	}
 


### PR DESCRIPTION
Stacktrace:

```
PHP message: PHP Fatal error:  Uncaught TypeError: mysqli_num_fields(): Argument #1 ($result) must be of type mysqli_result, null given in /var/www/wp-content/db.php:1440
Stack trace:
#0 /var/www/wp-content/db.php(1440): mysqli_num_fields(NULL)
#1 /var/www/wp-content/db.php(976): hyperdb->ex_mysql_num_fields(NULL)
#2 /var/www/wp-includes/class-wpdb.php(2774): hyperdb->query('SELECT option_v...')
#3 /var/www/wp-includes/option.php(199): wpdb->get_row('SELECT option_v...')
```