### PR TITLE
Require the new location of WPDB on WP 6.1+

### DIFF
--- a/db.php
+++ b/db.php
@@ -24,7 +24,12 @@ $wpdb = true;   // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 if ( defined( 'WPDB_PATH' ) ) {
 	/** @psalm-suppress UnresolvableInclude */
 	require_once WPDB_PATH;
+} elseif ( file_exists( ABSPATH . WPINC . '/class-wpdb.php' ) ) {
+	// WP 6.1 and later.
+	/** @psalm-suppress UnresolvableInclude */
+	require_once ABSPATH . WPINC . '/class-wpdb.php';
 } else {
+	// WP 6.0 and earlier.
 	/** @psalm-suppress UnresolvableInclude */
 	require_once ABSPATH . WPINC . '/wp-db.php';
 }


### PR DESCRIPTION
`wp-includes/wp-db.php` is deprecated, and `wp-includes/class-wpdb.php` should be used instead. Including the old file produces a PHP notice.

>  Deprecated: File wp-db.php is <strong>deprecated</strong> since version 6.1.0! Use wp-includes/class-wpdb.php instead. in wp-includes/functions.php on line 5606

See https://core.trac.wordpress.org/ticket/56268
