### PR TITLE
'FOR UPDATE' check in `is_write_query()`

### DIFF
--- a/db.php
+++ b/db.php
@@ -341,7 +341,10 @@ class hyperdb extends wpdb {
 	public function is_write_query( $q ) {
 		// Quick and dirty: only SELECT statements are considered read-only.
 		$q = ltrim( $q, "\r\n\t (" );
-		return ! preg_match( '/^(?:SELECT|SHOW|DESCRIBE|DESC|EXPLAIN)\s/i', $q );
+		return (
+			! preg_match( '/^(?:SELECT|SHOW|DESCRIBE|DESC|EXPLAIN)\s/i', $q )
+			|| preg_match( '/(\sFOR UPDATE)/i', $q )
+		);
 	}
 
 	/**

--- a/db.php
+++ b/db.php
@@ -1,12 +1,12 @@
 <?php
 
 /*
-Plugin Name: HyperDB
-Plugin URI: https://wordpress.org/plugins/hyperdb/
+Plugin Name: LudacrisDB
+Plugin URI: https://github.com/justinmaurerdotdev/HyperDB
 Description: An advanced database class that supports replication, failover, load balancing, and partitioning.
-Author: Automattic
+Author: Automattic, Justin Maurer
 License: GPLv2 or later
-Version: 1.9
+Version: 1.10
 */
 
 // phpcs:disable Squiz.PHP.CommentedOutCode.Found

--- a/db.php
+++ b/db.php
@@ -1447,7 +1447,13 @@ class hyperdb extends wpdb {
 		if ( ! $this->use_mysqli ) {
 			return mysql_query( $query, $dbh );
 		}
-
+		$driver = new mysqli_driver();
+		$this->suppress_errors();
+		if ($this->suppress_errors) {
+			$driver->report_mode = MYSQLI_REPORT_OFF;
+		} else {
+			$driver->report_mode = MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT;
+		}
 		return mysqli_query( $dbh, $query );
 	}
 

--- a/db.php
+++ b/db.php
@@ -1441,7 +1441,6 @@ class hyperdb extends wpdb {
 			return mysql_query( $query, $dbh );
 		}
 		$driver = new mysqli_driver();
-		$this->suppress_errors();
 		if ($this->suppress_errors) {
 			$driver->report_mode = MYSQLI_REPORT_OFF;
 		} else {

--- a/db.php
+++ b/db.php
@@ -1448,7 +1448,6 @@ class hyperdb extends wpdb {
 			return mysql_query( $query, $dbh );
 		}
 		$driver = new mysqli_driver();
-		$this->suppress_errors();
 		if ($this->suppress_errors) {
 			$driver->report_mode = MYSQLI_REPORT_OFF;
 		} else {

--- a/db.php
+++ b/db.php
@@ -1440,7 +1440,13 @@ class hyperdb extends wpdb {
 		if ( ! $this->use_mysqli ) {
 			return mysql_query( $query, $dbh );
 		}
-
+		$driver = new mysqli_driver();
+		$this->suppress_errors();
+		if ($this->suppress_errors) {
+			$driver->report_mode = MYSQLI_REPORT_OFF;
+		} else {
+			$driver->report_mode = MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT;
+		}
 		return mysqli_query( $dbh, $query );
 	}
 


### PR DESCRIPTION
When using Wordfence's 2FA implementation together with HyperDB, the `SELECT ... FOR UPDATE` queries are currently getting interpreted as "not a write query", which causes user authentication to fail on read-only database replicas. My understanding is that `SELECT ... FOR UPDATE` is a write lock solution, so it requires a write-able instance.

Here's Wordfence's code, for reference, from `wordfence/modules/login-security/classes/controller/totp.php:54`:
```
$record = $wpdb->get_row($wpdb->prepare("SELECT * FROM `{$table}` WHERE `user_id` = %d FOR UPDATE", $user->ID), ARRAY_A);
```

I assume Wordfence isn't the only plugin to use write locks like this, so it seems like this "quick and dirty" `is_write_query()` is due for an upgrade. This fix appears to be working for me in production.