### PR TITLE
Add db_server_info()

### DIFF
--- a/db.php
+++ b/db.php
@@ -1149,6 +1149,16 @@ class hyperdb extends wpdb {
 	 * @return false|string false on failure, version number on success
 	 */
 	public function db_version( $dbh_or_table = false ) {
+		$server_info = $this->db_server_info( $dbh_or_table );
+		return $server_info ? preg_replace( '/[^0-9.].*/', '', $server_info ) : false;
+	}
+
+	/**
+	 * Retrieves full database server information
+	 * @param false|string|resource $dbh_or_table the database (the current database, the database housing the specified table, or the database of the mysql resource)
+	 * @return string|false Server info on success, false on failure
+	 */
+	public function db_server_info( $dbh_or_table = false ) {
 		if ( ! $dbh_or_table && $this->dbh ) {
 			$dbh =& $this->dbh;
 		} elseif ( $this->is_mysql_connection( $dbh_or_table ) ) {
@@ -1157,10 +1167,7 @@ class hyperdb extends wpdb {
 			$dbh = $this->db_connect( "SELECT FROM $dbh_or_table $this->users" );
 		}
 
-		if ( $dbh ) {
-			return preg_replace( '/[^0-9.].*/', '', $this->ex_mysql_get_server_info( $dbh ) );
-		}
-		return false;
+		return $dbh ? $this->ex_mysql_get_server_info( $dbh ) : false;
 	}
 
 	/**


### PR DESCRIPTION
WP 5.5 added this method: https://github.com/WordPress/WordPress/blob/9c3b7e5e7c94f3f8c5f3766a0d25e801b39a81a5/wp-includes/class-wpdb.php#L3858-L3873

Using it can cause errors on sites though, because hyperdb might not have a connection ready to go, so you end up with:

```
Warning: mysqli_get_server_info() expects parameter 1 to be mysqli, null given in /var/www/wp-includes/class-wpdb.php on line 3867
```

We need to do the same thing we did for db_version() to resolve this. I have some questions though I'll leave in review comments.