### PR TITLE
Add a connect timeout explicitly to hyperdb. 

### DIFF
--- a/db.php
+++ b/db.php
@@ -1489,6 +1489,7 @@ class hyperdb extends wpdb {
 			$db_host = "p:{$db_host}";
 		}
 
+		mysqli_options( $dbh, MYSQLI_OPT_CONNECT_TIMEOUT, $this->ex_mysql_connect_timeout() );
 		$retval = mysqli_real_connect( $dbh, $db_host, $db_user, $db_password, null, $port, $socket, $client_flags );
 
 		if ( ! $retval || $dbh->connect_errno ) {


### PR DESCRIPTION
Add a connect timeout explicitly to wpdb. While this generally has the same effect as the default_socket_timeout ini setting, but hopefully in future PHPs it would apply to the whole handshake.

---

While upgrading HyperDB on WordPress.org, I spotted that we have a customization on WordPress.org & WordPress.com that hasn't been added to HyperDB on GitHub. 

It initially appears that this might be a bugfix that doesn't apply to HyperDB directly with currently released versions of PHP, but as I can't see any harm in upstreaming this, and can't find any open PHP Bugs seemingly related to it, I'm PR'ing it here for reference and determinations. 

@vnsavage I've requested review from you as you're the original author. Is this something that is safe to merge to HyperDB? Or should it be kept as a customization on the platforms?