### PR TITLE
Flush the query results variables following strip_invalid_text_from_query()

### DIFF
--- a/db.php
+++ b/db.php
@@ -934,6 +934,9 @@ class hyperdb extends wpdb {
 			// If we're writing to the database, make sure the query will write safely.
 			if ( $this->check_current_query && method_exists( $this, 'check_ascii' ) && ! $this->check_ascii( $query ) ) {
 				$stripped_query = $this->strip_invalid_text_from_query( $query );
+				// strip_invalid_text_from_query() can perform queries, so we need
+				// to flush again, just to make sure everything is clear.
+				$this->flush();
 				if ( $stripped_query !== $query ) {
 					$this->insert_id  = 0;
 					$this->last_error = 'Invalid query';


### PR DESCRIPTION
Flush the query results variables following strip_invalid_text_from_query() to ensure queries from that function does not get returned to the caller function.

[This changeset to wpdb](https://core.trac.wordpress.org/changeset/31093) was never added to to HyperDB.

18 months ago I merged it to our HyperDB on WordPress.org, but appear to have failed to create a PR here, and don't recall what I was fixing at the time. It appears it was likely causing PHP Notices somehow or causing problems in the WordPress.org stats.

[Based on the core bug it was fixing](https://core.trac.wordpress.org/ticket/30948), it appears it may also affect some unit tets.

@pento I don't suppose you recall any details of the above changeset, and if/why/not it should be added to HyperDB too?