### PR TITLE
Support `SELECT DISTINCT SQL_CALC_FOUND_ROWS`

### DIFF
--- a/db.php
+++ b/db.php
@@ -969,7 +969,7 @@ class hyperdb extends wpdb {
 			$elapsed = $this->timer_stop();
 			++$this->num_queries;
 
-			if ( preg_match( '/^\s*SELECT\s+SQL_CALC_FOUND_ROWS\s/i', $query ) ) {
+			if ( preg_match( '/^\s*SELECT\s+(DISTINCT\s+)?SQL_CALC_FOUND_ROWS\s/i', $query ) ) {
 				if ( false === strpos( $query, 'NO_SELECT_FOUND_ROWS' ) ) {
 					$this->timer_start();
 					$this->last_found_rows_result = $this->ex_mysql_query( 'SELECT FOUND_ROWS()', $this->dbh );


### PR DESCRIPTION
Fixes #136

The [MariaDB SELECT format is](https://mariadb.com/kb/en/select/)...
```
SELECT
    [ALL | DISTINCT | DISTINCTROW]
    [HIGH_PRIORITY]
    [STRAIGHT_JOIN]
    [SQL_SMALL_RESULT] [SQL_BIG_RESULT] [SQL_BUFFER_RESULT]
    [SQL_CACHE | SQL_NO_CACHE] [SQL_CALC_FOUND_ROWS]
    select_expr [, select_expr ...]
    [ FROM [table_references](https://mariadb.com/kb/en/join-syntax/)
```

The current regular expression therefor doesn't match any of the other query modifiers either, but `DISTINCT` is AFAIK the only one that WordPress would be using.