### PR TITLE
PHP 8.1: Fix addslashes(): Passing null to parameter #1 () of type string is deprecated

### DIFF
--- a/db.php
+++ b/db.php
@@ -841,7 +841,7 @@ class hyperdb extends wpdb {
 	 * This is also the reason why we don't allow certain charsets. See set_charset().
 	 */
 	public function _real_escape( $string ) {   // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
-		$escaped = addslashes( $string ?? '' );
+		$escaped = addslashes( ! is_null( $string ) ? $string : '' );
 		if ( method_exists( get_parent_class( $this ), 'add_placeholder_escape' ) ) {
 			$escaped = $this->add_placeholder_escape( $escaped );
 		}

--- a/db.php
+++ b/db.php
@@ -841,7 +841,7 @@ class hyperdb extends wpdb {
 	 * This is also the reason why we don't allow certain charsets. See set_charset().
 	 */
 	public function _real_escape( $string ) {   // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
-		$escaped = addslashes( ! is_null( $string ) ? $string : '' );
+		$escaped = addslashes( (string) $string );
 		if ( method_exists( get_parent_class( $this ), 'add_placeholder_escape' ) ) {
 			$escaped = $this->add_placeholder_escape( $escaped );
 		}

--- a/db.php
+++ b/db.php
@@ -841,7 +841,7 @@ class hyperdb extends wpdb {
 	 * This is also the reason why we don't allow certain charsets. See set_charset().
 	 */
 	public function _real_escape( $string ) {   // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
-		$escaped = addslashes( $string );
+		$escaped = addslashes( $string ?? '' );
 		if ( method_exists( get_parent_class( $this ), 'add_placeholder_escape' ) ) {
 			$escaped = $this->add_placeholder_escape( $escaped );
 		}


### PR DESCRIPTION
```
Deprecated: addslashes(): Passing null to parameter #1 ($string) of type string is deprecated in /wp/wp-content/mu-plugins/drop-ins/hyperdb/db.php on line 844 [es-site.vipdev.lndo.site/] [wp-content/mu-plugins/drop-ins/hyperdb/db.php:844 addslashes(), wp-includes/class-wpdb.php:1789 hyperdb-&gt;_real_escape(), wp-admin/includes/schema.php:1328 wpdb-&gt;prepare(), wp-admin/includes/schema.php:1040 populate_network_meta(), phar:///usr/local/binvendor/wp-cli/core-command/src/Core_Command.php:715 populate_network(), phar:///usr/local/binvendor/wp-cli/core-command/src/Core_Command.php:567 Core_Command-&gt;multisite_convert_(), Core_Command-&gt;multisite_install(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/CommandFactory.php:100 call_user_func(), WP_CLI\Dispatcher\CommandFactory::WP_CLI\Dispatcher\{closure}(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/Subcommand.php:491 call_user_func(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/WP_CLI/Runner.php:431 WP_CLI\Dispatcher\Subcommand-&gt;invoke(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/WP_CLI/Runner.php:454 WP_CLI\Runner-&gt;run_command(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/WP_CLI/Runner.php:1269 WP_CLI\Runner-&gt;run_command_and_exit(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/WP_CLI/Bootstrap/LaunchRunner.php:28 WP_CLI\Runner-&gt;start(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/bootstrap.php:83 WP_CLI\Bootstrap\LaunchRunner-&gt;process(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/wp-cli.php:32 WP_CLI\bootstrap(), phar:///usr/local/binphp/boot-phar.php:20 include(&#039;phar:///usr/local/binvendor/wp-cli/wp-cli/php/wp-cli.php&#039;), /usr/local/bin/wp:4 include(&#039;phar:///usr/local/binphp/boot-phar.php&#039;)]
```