### PR TITLE
Correctly identify whether the server supports `utf8mb4_520`

### DIFF
--- a/db.php
+++ b/db.php
@@ -1102,7 +1102,7 @@ class hyperdb extends wpdb {
 	/**
 	 * Generic function to determine if a database supports a particular feature
 	 * The additional argument allows the caller to check a specific database.
-  	 *
+	 *
 	 * @param string $db_cap the feature
 	 * @param false|string|resource $dbh_or_table the databaese (the current database, the database housing the specified table, or the database of the mysql resource)
 	 * @return bool


### PR DESCRIPTION
In older versions of PHP `$db_version` will be `5.5.5` for MariaDB, which prevents the use of the `utf8mb4_unicode_520_ci` collation.

See https://core.trac.wordpress.org/changeset/54384

This merges https://github.com/WordPress/wordpress-develop/commit/fed98bd9ef9a232d102c41e74944d3c21cd6183e & https://github.com/WordPress/wordpress-develop/commit/11df92738b07de35ae42fa6ee14c5ed506432241 to HyperDB.