### PR TITLE
Improve last error handling

### DIFF
--- a/db.php
+++ b/db.php
@@ -960,7 +960,7 @@ class hyperdb extends wpdb {
 				$this->ex_mysql_query( $statement_before_query, $this->dbh );
 			}
 
-			$this->result = $this->ex_mysql_query( $query, $this->dbh );
+			$this->result     = $this->ex_mysql_query( $query, $this->dbh );
 			$this->last_error = $this->ex_mysql_error( $this->dbh );
 
 			if ( $statement_after_query ) {

--- a/db.php
+++ b/db.php
@@ -961,6 +961,7 @@ class hyperdb extends wpdb {
 			}
 
 			$this->result = $this->ex_mysql_query( $query, $this->dbh );
+			$this->last_error = $this->ex_mysql_error( $this->dbh );
 
 			if ( $statement_after_query ) {
 				$query_for_log = "$query_for_log; $statement_after_query";
@@ -969,11 +970,12 @@ class hyperdb extends wpdb {
 			$elapsed = $this->timer_stop();
 			++$this->num_queries;
 
-			if ( preg_match( '/^\s*SELECT\s+SQL_CALC_FOUND_ROWS\s/i', $query ) ) {
+			if ( preg_match( '/^\s*SELECT\s+SQL_CALC_FOUND_ROWS\s/i', $query ) && false !== $this->result ) {
 				if ( false === strpos( $query, 'NO_SELECT_FOUND_ROWS' ) ) {
 					$this->timer_start();
 					$this->last_found_rows_result = $this->ex_mysql_query( 'SELECT FOUND_ROWS()', $this->dbh );
 					$elapsed                     += $this->timer_stop();
+					$this->last_error             = $this->ex_mysql_error( $this->dbh );
 					++$this->num_queries;
 					$query .= '; SELECT FOUND_ROWS()';
 				}
@@ -995,8 +997,6 @@ class hyperdb extends wpdb {
 				}
 			}
 		}
-
-		$this->last_error = $this->ex_mysql_error( $this->dbh );
 
 		if ( $this->last_error ) {
 			$this->last_errno = $this->ex_mysql_errno( $this->dbh );


### PR DESCRIPTION
## What

See: https://plugins.trac.wordpress.org/changeset/3123906/hyperdb/trunk

> Record the last_error closer to the queries so it's not lost and don't run 'SELECT FOUND_ROWS()' if the query has failed.

## How

```
svn diff -c 3123906 https://plugins.svn.wordpress.org/hyperdb/trunk/ | patch -p1 --fuzz=3
```
Followed by:
```
php vendor/bin/phpcbf
```


## Review steps

Please compare with the changeset above.