### PR TITLE
PHP 8.2 support: Add `AllowDynamicProperties `attribute

### DIFF
--- a/db.php
+++ b/db.php
@@ -69,8 +69,8 @@ define( 'HYPERDB_CONNNECTION_ERROR', 2002 ); // Can't connect to local MySQL ser
 define( 'HYPERDB_CONN_HOST_ERROR', 2003 ); // Can't connect to MySQL server on '%s' (%d)
 define( 'HYPERDB_SERVER_GONE_ERROR', 2006 ); // MySQL server has gone away
 
-// phpcs:ignore PEAR.NamingConventions.ValidClassName.StartWithCapital
 #[AllowDynamicProperties]
+// phpcs:ignore PEAR.NamingConventions.ValidClassName.StartWithCapital
 class hyperdb extends wpdb {
 	/**
 	 * The last table that was queried

--- a/db.php
+++ b/db.php
@@ -70,6 +70,7 @@ define( 'HYPERDB_CONN_HOST_ERROR', 2003 ); // Can't connect to MySQL server on '
 define( 'HYPERDB_SERVER_GONE_ERROR', 2006 ); // MySQL server has gone away
 
 // phpcs:ignore PEAR.NamingConventions.ValidClassName.StartWithCapital
+#[AllowDynamicProperties]
 class hyperdb extends wpdb {
 	/**
 	 * The last table that was queried


### PR DESCRIPTION
Dynamic (non-explicitly declared) properties are deprecated as of PHP 8.2 and are expected to become a fatal error in PHP 9.0.

Reference: [PHP RFC: Deprecate dynamic properties](https://wiki.php.net/rfc/deprecate_dynamic_properties).

This PR resolves the following deprecation warnings:

```php
 Deprecated: Creation of dynamic property hyperdb::$callback_result is deprecated
 Deprecated: Creation of dynamic property hyperdb::$current_host is deprecated
 Deprecated: Creation of dynamic property hyperdb::$dataset is deprecated
 Deprecated: Creation of dynamic property hyperdb::$dbhname is deprecated
 Deprecated: Creation of dynamic property hyperdb::$lag is deprecated
 Deprecated: Creation of dynamic property hyperdb::$lag_cache_key is deprecated
 Deprecated: Creation of dynamic property hyperdb::$lag_threshold is deprecated
 Deprecated: Creation of dynamic property hyperdb::$last_connection is deprecated
 Deprecated: Creation of dynamic property hyperdb::$last_errno is deprecated
 Deprecated: Creation of dynamic property hyperdb::$table is deprecated
```

It applies a similar fix as used by the WordPress core:

https://github.com/WordPress/WordPress/blob/master/wp-includes/class-wp-user.php#L41-L42

```php
#[AllowDynamicProperties]
class WP_User {
```