### PR TITLE
fix: `Function mysqli_ping() is deprecated since 8.4` and no longer tries to reconnect since PHP 8.2

### DIFF
--- a/db.php
+++ b/db.php
@@ -1555,7 +1555,14 @@ class hyperdb extends wpdb {
 			return @mysql_ping( $dbh );
 		}
 
-		return @mysqli_ping( $dbh );
+		// Deprecated: Function mysqli_ping() is deprecated since 8.4
+		if ( version_compare( PHP_VERSION, '8.4.0', '<' ) ) {
+			return @mysqli_ping( $dbh );
+		}
+
+		// Emulate ping with a simple query
+		$res = $this->ex_mysql_query( 'SELECT /* hyperbd::ex_mysql_ping */ 1', $dbh );
+		return is_object( $res ) && $res->num_rows === 1;
 	}
 
 	public function ex_mysql_affected_rows( $dbh ) {

--- a/db.php
+++ b/db.php
@@ -1556,7 +1556,7 @@ class hyperdb extends wpdb {
 		}
 
 		// Deprecated: Function mysqli_ping() is deprecated since 8.4
-		if ( version_compare( PHP_VERSION, '8.4.0', '<' ) ) {
+		if ( version_compare( PHP_VERSION, '8.2.0', '<' ) ) {
 			return @mysqli_ping( $dbh );
 		}
 

--- a/db.php
+++ b/db.php
@@ -1560,9 +1560,14 @@ class hyperdb extends wpdb {
 			return @mysqli_ping( $dbh );
 		}
 
-		// Emulate ping with a simple query
-		$res = $this->ex_mysql_query( 'SELECT /* hyperbd::ex_mysql_ping */ 1', $dbh );
-		return is_object( $res ) && 1 === $res->num_rows;
+		$res = $this->ex_mysql_query( 'SELECT /* hyperdb::ex_mysql_ping */ 1', $dbh );
+		if ( is_object( $res ) && 1 === $res->num_rows ) {
+			// The "ping" query was enough, the database connection is still there.
+			return true;
+		}
+
+		trigger_error( 'hyperdb::ex_mysql_ping needs to reconnect to the database', E_USER_WARNING );
+		return $this->is_mysql_connection( $this->db_connect() );
 	}
 
 	public function ex_mysql_affected_rows( $dbh ) {

--- a/db.php
+++ b/db.php
@@ -1562,7 +1562,7 @@ class hyperdb extends wpdb {
 
 		// Emulate ping with a simple query
 		$res = $this->ex_mysql_query( 'SELECT /* hyperbd::ex_mysql_ping */ 1', $dbh );
-		return is_object( $res ) && $res->num_rows === 1;
+		return is_object( $res ) && 1 === $res->num_rows;
 	}
 
 	public function ex_mysql_affected_rows( $dbh ) {

--- a/db.php
+++ b/db.php
@@ -1556,6 +1556,7 @@ class hyperdb extends wpdb {
 		}
 
 		// Deprecated: Function mysqli_ping() is deprecated since 8.4
+		// The mysqli.reconnect php.ini setting had been ignored by the mysqlnd driver, and was removed as of PHP 8.2.0.
 		if ( version_compare( PHP_VERSION, '8.2.0', '<' ) ) {
 			return @mysqli_ping( $dbh );
 		}

--- a/db.php
+++ b/db.php
@@ -1402,8 +1402,8 @@ class hyperdb extends wpdb {
 		// MySQL server has gone away
 		if ( isset( $this->dbhname_heartbeats[ $this->dbhname ]['last_errno'] ) &&
 			HYPERDB_SERVER_GONE_ERROR == $this->dbhname_heartbeats[ $this->dbhname ]['last_errno'] ) {
-			unset( $this->dbhname_heartbeats[ $this->dbhname ]['last_errno'] );
-			return true;
+			$this->disconnect( $this->dbhname );
+			return false;
 		}
 
 		// More than 0.1 seconds of inactivity on that dbhname

--- a/db.php
+++ b/db.php
@@ -1566,7 +1566,6 @@ class hyperdb extends wpdb {
 			return true;
 		}
 
-		trigger_error( 'hyperdb::ex_mysql_ping needs to reconnect to the database', E_USER_WARNING );
 		return $this->is_mysql_connection( $this->db_connect() );
 	}
 

--- a/db.php
+++ b/db.php
@@ -1566,7 +1566,8 @@ class hyperdb extends wpdb {
 			return true;
 		}
 
-		return $this->is_mysql_connection( $this->db_connect() );
+		// Let the hyperdb logic reconnect us.
+		return false;
 	}
 
 	public function ex_mysql_affected_rows( $dbh ) {


### PR DESCRIPTION
This PR resolves `Deprecated: Function mysqli_ping() is deprecated since 8.4` warnings.

The change has been checked internally and works fine - the lost connection is detected, the re-connection takes place and the query is sent properly.

### Resources

* https://www.php.net/manual/en/mysqli.ping.php
* https://php.watch/versions/8.2/mysqli-libmysql-no-longer-supported#mysqli-reconnect