### PR TITLE
fix: admin cannot add new posts

### DIFF
--- a/db.php
+++ b/db.php
@@ -33,15 +33,20 @@ if ( defined( 'WPDB_PATH' ) ) {
 	/** @psalm-suppress UnresolvableInclude */
 	require_once ABSPATH . WPINC . '/wp-db.php';
 }
-// Check if we are in wp-admin area
-// We can only check WP_ADMIN constant here as WordPress functions are not loaded yet
-$is_admin_area = defined('WP_ADMIN') && WP_ADMIN === true;
+// Check if we are in post-new.php page bypass hyperdb
+$is_post_new = false;
+if (defined('WP_ADMIN') && WP_ADMIN === true) {
+    // Get the current script name from PHP_SELF
+    $script_name = isset($_SERVER['PHP_SELF']) ? basename($_SERVER['PHP_SELF']) : '';
+    $is_post_new = ($script_name === 'post-new.php');
+}
 
-// If we're in admin area, bypass HyperDB and use standard database connection
-if ($is_admin_area) {
+// If we're in post-new.php, bypass HyperDB and use standard database connection
+if ($is_post_new) {
     $wpdb = new wpdb( DB_USER, DB_PASSWORD, DB_NAME, DB_HOST );
     return;
 }
+
 
 
 // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedIf

--- a/db.php
+++ b/db.php
@@ -33,6 +33,16 @@ if ( defined( 'WPDB_PATH' ) ) {
 	/** @psalm-suppress UnresolvableInclude */
 	require_once ABSPATH . WPINC . '/wp-db.php';
 }
+// Check if we are in wp-admin area
+// We can only check WP_ADMIN constant here as WordPress functions are not loaded yet
+$is_admin_area = defined('WP_ADMIN') && WP_ADMIN === true;
+
+// If we're in admin area, bypass HyperDB and use standard database connection
+if ($is_admin_area) {
+    $wpdb = new wpdb( DB_USER, DB_PASSWORD, DB_NAME, DB_HOST );
+    return;
+}
+
 
 // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedIf
 if ( defined( 'DB_CONFIG_FILE' ) && file_exists( DB_CONFIG_FILE ) ) {


### PR DESCRIPTION
error handling in report #166 By excluding the admin from using the features in the administration, ensuring data is always accurate and timely, users will still be able to navigate as usual.