### PR TITLE
Flag HyperDB as a MySQL dropin.

### DIFF
--- a/db.php
+++ b/db.php
@@ -233,6 +233,13 @@ class hyperdb extends wpdb {
 	public $num_failed_queries = 0;
 
 	/**
+	 * Let WordPress know this is a MySQL dropin.
+	 *
+	 * @see https://core.trac.wordpress.org/changeset/19060
+	 */
+	public $is_mysql = true;
+
+	/**
 	 * Gets ready to make database connections
 	 * @param array db class vars
 	 */


### PR DESCRIPTION
This needs proper testing..

Based on HyperDB behaviour, this might cause the other conditions in the update-core files to fail: https://github.com/WordPress/wordpress-develop/commit/fcf1696de4ff140fcc154b8305320a6ba676c47b

Those conditions seem to still apply: https://github.com/WordPress/wordpress-develop/blob/16aa10f04dfaa8b9084f05213a9371526dc3e79b/src/wp-admin/includes/update-core.php#L1126-L1140

Core should probably check to see if the `$mysql_version` is falsey there.

Fixes #160