### PR TITLE
Handle null input in _real_escape method.

### DIFF
--- a/db.php
+++ b/db.php
@@ -842,6 +842,9 @@ class hyperdb extends wpdb {
 	 * This is also the reason why we don't allow certain charsets. See set_charset().
 	 */
 	public function _real_escape( $string ) {   // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+		if ( is_null( $string ) ) {
+			return $string;
+		}
 		$escaped = addslashes( (string) $string );
 		if ( method_exists( get_parent_class( $this ), 'add_placeholder_escape' ) ) {
 			$escaped = $this->add_placeholder_escape( $escaped );


### PR DESCRIPTION
WordPress accepts NULL input in `wpdb::prepare()` which is ultimately passed through to this method.

This triggers a PHP Deprecated warning:
```
 PHP Deprecated:  addslashes(): Passing null to parameter #1 ($string) of type string is deprecated
```