### PR TITLE
Replace mysqli_ping() with a DO 1 health check

### DIFF
--- a/db.php
+++ b/db.php
@@ -1555,7 +1555,8 @@ class hyperdb extends wpdb {
 			return @mysql_ping( $dbh );
 		}
 
-		return @mysqli_ping( $dbh );
+		// PHP 8.4 deprecated mysqli_ping(); issue a lightweight query instead.
+		return false !== @mysqli_query( $dbh, 'DO 1' );
 	}
 
 	public function ex_mysql_affected_rows( $dbh ) {


### PR DESCRIPTION
## Summary
- replace `mysqli_ping()` with a lightweight `DO 1` query in HyperDB
- preserve the existing boolean health-check behavior for reused mysqli connections
- avoid the PHP 8.4 deprecation triggered by `mysqli_ping()`

## Testing
- `php -l db.php`
- not run: HyperDB does not have a local test harness in this checkout