### PR TITLE
Update Harden Runner action

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -12,7 +12,7 @@ jobs:
     name: Review Dependencies
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@v2.16.0
         with:
           egress-policy: block
           allowed-endpoints: >


### PR DESCRIPTION
## Summary
- Updates `step-security/harden-runner` in the dependency review workflow from the floating `v2` reference to `v2.16.0`.
- Addresses the open Harden Runner Dependabot alerts in `.github/workflows/dependency-review.yml`.

## Validation
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/dependency-review.yml'); puts 'workflow yaml parsed'"`
- Confirmed `v2.16.0` exists upstream.
- `git diff --check`

## Notes
- This intentionally keeps the PR scoped to the alerted action. The older open Dependabot PRs for checkout, dependency-review-action, composer-install, and Composer packages are maintenance backlog, not current security-alert blockers.
