### PR TITLE
chore: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -12,7 +12,7 @@ jobs:
     name: Review Dependencies
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@v2.16.0
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
         with:
           egress-policy: block
           allowed-endpoints: >


### PR DESCRIPTION
Pins third-party GitHub Actions in this repo to commit SHAs (with the original tag preserved as a trailing comment), to harden against supply-chain attacks via mutable tags.

After merge, Dependabot (already enabled for `github-actions` here) will keep these SHAs current automatically.

Tracking: DEVPROD-1072.
