### PR TITLE
chore: silence Dependabot major-version bumps for github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - version-update:semver-major


### PR DESCRIPTION
Adds an `ignore` rule so Dependabot stops opening PRs for major-version bumps of GitHub Actions. Patch and minor refreshes (the security-relevant ones) continue as before. Dependabot security updates (CVE-triggered) are unaffected and still fire on majors.

Tracking: DEVPROD-1072.