### PR TITLE
chore: refresh setup-php pin label

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3.0.2
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@1a18b2267f80291a81ca1d33e7c851fe09e7dfc4 # tag=v2.21.2
+        uses: shivammathur/setup-php@1a18b2267f80291a81ca1d33e7c851fe09e7dfc4 # tag=2.22.0
         with:
           php-version: ${{ env.PHP_VERSION }}
           coverage: none

--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3.0.2
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@1a18b2267f80291a81ca1d33e7c851fe09e7dfc4 # tag=v2.21.2
+        uses: shivammathur/setup-php@1a18b2267f80291a81ca1d33e7c851fe09e7dfc4 # tag=2.22.0
         with:
           php-version: ${{ env.PHP_VERSION }}
 


### PR DESCRIPTION
Follow-up to https://github.com/Automattic/HyperDB/pull/173.

That PR pinned `shivammathur/setup-php` correctly, but left the trailing label as `tag=v2.21.2`. That tag no longer resolves; the same pinned commit is tagged `2.22.0`.

DEVPROD-1072
